### PR TITLE
Suppress the display of the "Error: Unable to initialize GTK+..." message when running diff-pdf with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            command: diff-pdf
+            command: xvfb-run -a diff-pdf
           - os: windows-latest
             command: diff-pdf.exe
 


### PR DESCRIPTION
This fixes https://github.com/hidakatsuya/setup-diff-pdf/issues/22