### PR TITLE
Update to the node16 runtime by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: diff-pdf version. e.g. "0.5"
     required: true
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/