### PR TITLE
Suppress the warning to use apt-get instead of apt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - if: matrix.os == 'ubuntu-latest'
-      run: sudo apt install at-spi2-core
+      run: sudo apt-get install at-spi2-core
 
     - uses: actions/checkout@v3
 

--- a/src/linux.js
+++ b/src/linux.js
@@ -11,8 +11,8 @@ const REQUIRED_PACKAGES = [
 ];
 
 export async function setup(version) {
-  await exec.exec('sudo apt update');
-  await exec.exec(`sudo apt install ${REQUIRED_PACKAGES.join(' ')}`);
+  await exec.exec('sudo apt-get update');
+  await exec.exec(`sudo apt-get install ${REQUIRED_PACKAGES.join(' ')}`);
   await exec.exec(`git clone https://github.com/vslavik/diff-pdf.git -b v${version} --depth 1 ${WORKING_DIR}`);
 
   const buildOptions = {


### PR DESCRIPTION
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts
```

See also: https://askubuntu.com/questions/990823/apt-gives-unstable-cli-interface-warning